### PR TITLE
#137 Get device memory information

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "anstyle",
  "doc-comment",
  "globwalk",
- "predicates",
+ "predicates 3.0.3",
  "predicates-core",
  "predicates-tree",
  "tempfile",
@@ -167,6 +167,23 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "battery"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b624268937c0e0a3edb7c27843f9e547c320d730c610d3b8e6e8e95b2026e4"
+dependencies = [
+ "cfg-if",
+ "core-foundation 0.7.0",
+ "lazycell",
+ "libc",
+ "mach",
+ "nix",
+ "num-traits",
+ "uom",
+ "winapi",
+]
 
 [[package]]
 name = "bitflags"
@@ -339,7 +356,7 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics",
  "foreign-types",
  "libc",
@@ -354,7 +371,7 @@ checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -385,13 +402,29 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -406,7 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -419,7 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
 ]
@@ -650,6 +683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +839,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futf"
@@ -1554,6 +1608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1673,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -1720,6 +1789,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates 2.1.5",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "multer"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1886,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +1908,12 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -2269,6 +2383,20 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
@@ -2669,8 +2797,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.3",
  "libc",
  "security-framework-sys",
 ]
@@ -2681,7 +2809,7 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 
@@ -2720,10 +2848,13 @@ version = "0.5.0"
 dependencies = [
  "assert_fs",
  "axum",
+ "battery",
  "dirs",
  "filesize",
  "futures",
  "lazy_static",
+ "mockall",
+ "num-traits",
  "pnet_datalink",
  "portpicker",
  "reqwest",
@@ -3081,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9557d0845b86eea8182f7b10dff120214fb6cd9fd937b6f4917714e546a38695"
 dependencies = [
  "cfg-if",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
  "ntapi",
  "once_cell",
@@ -3125,7 +3256,7 @@ dependencies = [
  "cairo-rs",
  "cc",
  "cocoa",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3772,6 +3903,16 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "uom"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76503e636584f1e10b9b3b9498538279561adcef5412927ba00c2b32c4ce5ed"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "uptime_lib"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,6 +39,9 @@ tracing-subscriber = {version = "0.3.16", features = ["env-filter"] }
 uptime_lib = "0.2.2"
 walkdir = "2.3.3"
 wildmatch = "2.1.1"
+battery = "0.7.8"
+num-traits = "0.2.15"
+mockall = "0.11.4"
 
 [dependencies.tauri-plugin-sqlite]
 git = "https://github.com/lzdyes/tauri-plugin-sqlite"

--- a/core/src/utils/system_info.rs
+++ b/core/src/utils/system_info.rs
@@ -1,7 +1,7 @@
 use std::{fmt, net::Ipv4Addr};
 
 use battery::units::time::*;
-use battery::{Battery, Manager};
+use battery::Manager;
 use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use sys_info;
@@ -9,6 +9,103 @@ use sys_info;
 use crate::SERVER_PORT;
 
 use super::{compute_file_size, ip_manager::autodetect_ip_address};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MockSystemInformation {
+    /// the current user name eg - drizzle
+    pub system_name: String,
+    /// available store
+    pub available_disk: String,
+    /// used store
+    pub used_disk: String,
+    /// the port on which the core server runs
+    port: u128,
+    /// the battery remaining time
+    /// could be none if the battery is charging
+    pub remaining_time: Option<String>,
+    /// the system ip address
+    pub ip_address: Ipv4Addr,
+    /// the server base URL constructed form the ip address and port
+    pub server_base_url: String,
+}
+
+impl std::default::Default for MockSystemInformation {
+    fn default() -> Self {
+        Self {
+            system_name: String::from(""),
+            available_disk: String::from(""),
+            used_disk: String::from(""),
+            remaining_time: None,
+            port: 0,
+            ip_address: Ipv4Addr::from([0, 0, 0, 0]),
+            server_base_url: String::from(""),
+        }
+    }
+}
+
+/// system information construct
+/// accepts the system name name and returns an instance of the struct with the remaining values constructed internally
+
+impl MockSystemInformation {
+    pub fn new(disk_total: Option<u64>, disk_free: Option<u64>, r_time: Option<u64>) -> Self {
+        let port = *SERVER_PORT;
+        let system_name = match sys_info::hostname() {
+            Ok(name) => name,
+            Err(_) => String::from("guest computer"),
+        };
+        let ip_address = match autodetect_ip_address() {
+            Ok(ip) => ip.parse::<Ipv4Addr>(),
+            Err(_) => Ok(Ipv4Addr::from([0, 0, 0, 0])),
+        };
+
+        // Get the used memory information
+        let mut disk_info: Result<sys_info::DiskInfo, sys_info::Error> = match disk_total {
+            Some(total) => match disk_free {
+                Some(free) => Ok(sys_info::DiskInfo { total, free }),
+                None => Err(sys_info::Error::UnsupportedSystem),
+            },
+            None => Err(sys_info::Error::UnsupportedSystem),
+        };
+
+        let mut available_disk = 0;
+        let mut used_disk = 0;
+        match disk_info {
+            Ok(info) => {
+                available_disk = info.free;
+                used_disk = info.total - info.free;
+            }
+            Err(_) => {
+                println!("Failed to get the disk information");
+            }
+        };
+
+        let remaining_time = match r_time {
+            Some(mut seconds) => {
+                let remaining_hours = seconds / 3600;
+                seconds %= 3600;
+                let remaining_minutes = seconds / 60;
+                seconds %= 60;
+                let remaining_seconds = seconds;
+                Some(format!(
+                    "{:02}:{:02}:{:02}",
+                    remaining_hours, remaining_minutes, remaining_seconds
+                ))
+            }
+            None => None,
+        };
+
+        Self {
+            system_name,
+            available_disk: compute_file_size(available_disk as u128),
+            used_disk: compute_file_size(used_disk as u128),
+            port: port.into(),
+            ip_address: ip_address.clone().unwrap(),
+            server_base_url: format!("http://{}:{}", ip_address.unwrap(), port),
+            remaining_time: remaining_time,
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,14 +118,13 @@ pub struct SystemInformation {
     pub used_disk: String,
     /// the port on which the core server runs
     port: u128,
-    /// the remaining_time e.g 2 hours     
-    pub remaining_time: String,
+    /// the battery remaining time
+    /// could be none if the battery is charging
+    pub remaining_time: Option<String>,
     /// the system ip address
     pub ip_address: Ipv4Addr,
     /// the server base URL constructed form the ip address and port
     pub server_base_url: String,
-    /// the battery state
-    pub battery_is_charging: bool,
 }
 
 impl std::default::Default for SystemInformation {
@@ -37,11 +133,10 @@ impl std::default::Default for SystemInformation {
             system_name: String::from(""),
             available_disk: String::from(""),
             used_disk: String::from(""),
-            remaining_time: String::from(""),
+            remaining_time: None,
             port: 0,
             ip_address: Ipv4Addr::from([0, 0, 0, 0]),
             server_base_url: String::from(""),
-            battery_is_charging: false,
         }
     }
 }
@@ -76,20 +171,20 @@ impl SystemInformation {
             }
         };
 
-        let charging_battery = Self::battery_is_discharging();
-        let mut remaining_seconds = 0;
-        let mut remaining_minutes = 0;
-        let mut remaining_hours = 0;
-        match Self::remaining_battery_time() {
+        let remaining_time = match Self::remaining_battery_time() {
             Some(mut seconds) => {
-                remaining_hours = seconds / 3600;
+                let remaining_hours = seconds / 3600;
                 seconds %= 3600;
-                remaining_minutes = seconds / 60;
+                let remaining_minutes = seconds / 60;
                 seconds %= 60;
-                remaining_seconds = seconds;
+                let remaining_seconds = seconds;
+                Some(format!(
+                    "{:02}:{:02}:{:02}",
+                    remaining_hours, remaining_minutes, remaining_seconds
+                ))
             }
-            None => (),
-        }
+            None => None,
+        };
 
         Self {
             system_name,
@@ -98,39 +193,22 @@ impl SystemInformation {
             port: port.into(),
             ip_address: ip_address.clone().unwrap(),
             server_base_url: format!("http://{}:{}", ip_address.unwrap(), port),
-            remaining_time: format!(
-                "{hour:02}:{minute:02}:{second:02}",
-                hour = remaining_hours,
-                minute = remaining_minutes,
-                second = remaining_seconds
-            ),
-            battery_is_charging: charging_battery,
+            remaining_time: remaining_time,
         }
     }
-
     fn get_disk_info() -> Result<sys_info::DiskInfo, sys_info::Error> {
         sys_info::disk_info()
     }
-    fn get_battery_info() -> Result<Battery, battery::Error> {
-        Manager::new()?.batteries()?.enumerate().nth(0).unwrap().1
-    }
-    fn battery_is_discharging() -> bool {
-        match Self::get_battery_info() {
-            Ok(battery) => {
-                if battery.state() == battery::State::Discharging {
-                    return false;
-                } else {
-                    return true;
-                }
-            }
-            Err(e) => {
-                println!("Failed to get the battery information.\n{:?}", e);
-                return false;
-            }
-        }
-    }
     fn remaining_battery_time() -> Option<u64> {
-        match Self::get_battery_info() {
+        match Manager::new()
+            .expect("Failed to get battery manager")
+            .batteries()
+            .expect("Failed to get batteries")
+            .enumerate()
+            .nth(0)
+            .unwrap()
+            .1
+        {
             Ok(battery) => return battery.time_to_empty()?.get::<second>().to_u64(),
             Err(e) => {
                 println!("Failed to get the battery information.\n{:?}", e);
@@ -157,7 +235,10 @@ impl fmt::Display for SystemInformation {
             self.available_disk,
             self.used_disk,
             self.port,
-            self.remaining_time,
+            match &self.remaining_time {
+                Some(time) => time,
+                None => "None",
+            },
             self.ip_address,
             self.server_base_url
         )
@@ -167,23 +248,67 @@ impl fmt::Display for SystemInformation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockall::predicate::*;
-    use mockall::*;
+    fn disk_info_should_be(available_disk: u64, used_disk: u64) -> (String, String) {
+        (format!("{} B", available_disk), format!("{} B", used_disk))
+    }
     #[test]
-    fn test_battery_discharging() {
-        let target = (128, 1024 - 128);
-        let mut result = MockSystemInformation::new();
-        result.expect_get_disk_info().returning(sys_info::DiskInfo {
-            total: 1024,
-            free: 128,
-        });
+    fn test_disk_info_available() {
+        let target = disk_info_should_be(128, 1024 - 128);
+        let result = MockSystemInformation::new(Some(1024), Some(128), None);
         assert_eq!((result.available_disk, result.used_disk), target);
     }
-
     #[test]
-    fn test_battery_remaining_time() {
-        let target = "00:00:12";
-        let result = SystemInformation::new();
+    fn test_disk_info_unavailable() {
+        let target = disk_info_should_be(0, 0);
+        let result = MockSystemInformation::new(None, None, None);
+        assert_eq!((result.available_disk, result.used_disk), target);
+    }
+    #[test]
+    fn test_disk_info_total_unavailable() {
+        let target = disk_info_should_be(0, 0);
+        let result = MockSystemInformation::new(None, Some(128), None);
+        assert_eq!((result.available_disk, result.used_disk), target);
+    }
+    #[test]
+    fn test_disk_info_free_unavailable() {
+        let target = disk_info_should_be(0, 0);
+        let result = MockSystemInformation::new(Some(128), None, None);
+        assert_eq!((result.available_disk, result.used_disk), target);
+    }
+    #[test]
+    fn test_battery_remaining_time_seconds() {
+        let target: Option<String> = Some(format!("00:00:12"));
+        let result = MockSystemInformation::new(None, None, Some(12));
+        assert_eq!(result.remaining_time, target);
+    }
+    #[test]
+    fn test_battery_remaining_time_minures() {
+        let target: Option<String> = Some(format!("00:12:00"));
+        let result = MockSystemInformation::new(None, None, Some(720));
+        assert_eq!(result.remaining_time, target);
+    }
+    #[test]
+    fn test_battery_remaining_time_hours() {
+        let target: Option<String> = Some(format!("12:00:00"));
+        let result = MockSystemInformation::new(None, None, Some(43200));
+        assert_eq!(result.remaining_time, target);
+    }
+    #[test]
+    fn test_battery_remaining_time_hours_minutes_and_secons() {
+        let target: Option<String> = Some(format!("01:01:01"));
+        let result = MockSystemInformation::new(None, None, Some(3661));
+        assert_eq!(result.remaining_time, target);
+    }
+    #[test]
+    fn test_battery_remaining_time_exceed_99_hours() {
+        let target: Option<String> = Some(format!("100:00:00"));
+        let result = MockSystemInformation::new(None, None, Some(360000));
+        assert_eq!(result.remaining_time, target);
+    }
+    #[test]
+    fn test_battery_is_charging() {
+        let target: Option<String> = None;
+        let result = MockSystemInformation::new(None, None, None);
         assert_eq!(result.remaining_time, target);
     }
 }


### PR DESCRIPTION
I have refactored the 'SystemInformation' struct and made the following changes:

- Total available memory: Renamed to 'available_disk' since it represents the available space on the disk.
- Used memory: Renamed to 'used_disk' as it denotes the used space on the disk.
- Device battery uptime in hh mm (hour and minutes): Renamed to 'remaining_time' to indicate the remaining time until the battery is depleted. Furthermore, the charging state of the battery should be determined based on the remaining time. If the battery is charging, the remaining time should be 'None', while a value should be present when the battery is discharging